### PR TITLE
Add pointer to and from UInt

### DIFF
--- a/src/last-wasm/codegen.spec.ts
+++ b/src/last-wasm/codegen.spec.ts
@@ -1047,6 +1047,15 @@ describe("last codegen", () => {
                             expect(test(15)).toBe(15)
                         })
                     })
+                    it("can convert to a Pointer", () => {
+                        cg(`
+                            var a: Int;
+                            var b: Int^ = &a;
+                            export fun test(): UInt = b as UInt;
+                        `, ({test}) => {
+                            expect(test()).toEqual(4)
+                        })
+                    })
                 })
             })
             describe("i64", () => {
@@ -1673,7 +1682,7 @@ function cg(text: string, cb: (exports: any) => void, name: string = "<text>"): 
                 sourceMap.addMapping(mapping.offset, fileIndex, position.line, position.column)
             }
         }
-        const sourceMapText = sourceMap.toMap()
+        const sourceMapText = sourceMap.toMap(name == "<text>" ? text : undefined)
         fs.writeFileSync("out/tmp.wasm.map", sourceMapText, "utf8")
     }
 

--- a/src/last-wasm/codegen.ts
+++ b/src/last-wasm/codegen.ts
@@ -464,11 +464,11 @@ export function codegen(
         const alloc = scopes.alloc
         const nodes = scopes.nodes
         const nodeValue = node.value
-        const value = nodeValue ? lastToGenNode(nodeValue, scopes) : emptyGenNode
+        const value = nodeValue ? lastToGenNode(nodeValue, scopes) : undefined
         const type = typeOf(node)
         const varGenNode = alloc.allocate(node, type, value)
         nodes.enter(node.name.name, varGenNode)
-        if (nodeValue)
+        if (value)
             return new AssignGenNode(node, varGenNode, value)
         else return emptyGenNode
     }

--- a/src/last/check.spec.ts
+++ b/src/last/check.spec.ts
@@ -270,6 +270,21 @@ describe("check", () => {
             `)
         })
     })
+    describe("pointers", () => {
+        it("can check a pointer converted to an UInt", () => {
+            t(`
+                var a: Int;
+                var b: Int^ = &a;
+                var c: UInt = b as UInt;
+            `)
+        })
+        it("can check a conversion of a UInt to a pointer", () => {
+            t(`
+                var a: UInt;
+                var b: Int^ = a as Int^;
+            `)
+        })
+    })
 })
 
 function report(text: string, name: string, diagnostics: Diagnostic[], fileSet: FileSet | undefined): never {

--- a/src/source-map.ts
+++ b/src/source-map.ts
@@ -22,7 +22,7 @@ export class SourceMap {
         this.mappings.push({ offset, fileIndex, line, column, name })
     }
 
-    toMap(): string {
+    toMap(sourceContent?: string): string {
         const mappingArray = this.mappings.sort((a, b) => a.offset - b.offset)
         let previousOffset = 0
         let previousLine = 0
@@ -56,7 +56,9 @@ export class SourceMap {
             names: this.names,
             mappings
         }
-
+        if (sourceContent) {
+            mapData.sourceContent = sourceContent
+        }
         if (this.target) mapData.file = this.target
         if (this.sourceRoot) mapData.sourceRoot = this.sourceRoot
 
@@ -92,6 +94,7 @@ interface SourceMapData {
     sources: string[]
     names: string[]
     mappings: string
+    sourceContent?: string
 }
 
 interface Mapping {


### PR DESCRIPTION
Adding conversion to and from UInt to allow lower level
pointer manipulation such as required for implementing
memory allocators and/or a stack.