### PR TITLE
Fix rotation

### DIFF
--- a/src/last-wasm/codegen.spec.ts
+++ b/src/last-wasm/codegen.spec.ts
@@ -169,16 +169,6 @@ describe("last codegen", () => {
                             expect(test(7, 2)).toEqual(7 << 2)
                         })
                     })
-                    it("can bitwise ror", () => {
-                        cg("export fun test(a: Int8, b: Int32): Int8 = a ror b", ({test}) => {
-                            expect(test(7, 2)).toEqual(7 >> 2)
-                        })
-                    })
-                    it("can bitwise rol", () => {
-                        cg("export fun test(a: Int8, b: Int32): Int8 = a rol b", ({test}) => {
-                            expect(test(7, 2)).toEqual(7 << 2)
-                        })
-                    })
                 })
                 it("can compare", () => {
                     cg("export fun test(a: Int8, b: Int8): Boolean = a > b", ({test}) => {
@@ -330,16 +320,6 @@ describe("last codegen", () => {
                     })
                     it("can bitwise shl", () => {
                         cg("export fun test(a: UInt8, b: Int32): UInt8 = a shl b", ({test}) => {
-                            expect(test(7, 2)).toEqual(7 << 2)
-                        })
-                    })
-                    it("can bitwise ror", () => {
-                        cg("export fun test(a: UInt8, b: Int32): UInt8 = a ror b", ({test}) => {
-                            expect(test(7, 2)).toEqual(7 >> 2)
-                        })
-                    })
-                    it("can bitwise rol", () => {
-                        cg("export fun test(a: UInt8, b: Int32): UInt8 = a rol b", ({test}) => {
                             expect(test(7, 2)).toEqual(7 << 2)
                         })
                     })
@@ -497,16 +477,6 @@ describe("last codegen", () => {
                             expect(test(7, 2)).toEqual(7 << 2)
                         })
                     })
-                    it("can bitwise ror", () => {
-                        cg("export fun test(a: Int16, b: Int32): Int16 = a ror b", ({test}) => {
-                            expect(test(7, 2)).toEqual(7 >> 2)
-                        })
-                    })
-                    it("can bitwise rol", () => {
-                        cg("export fun test(a: Int8, b: Int32): Int8 = a rol b", ({test}) => {
-                            expect(test(7, 2)).toEqual(7 << 2)
-                        })
-                    })
                 })
                 it("can compare", () => {
                     cg("export fun test(a: Int16, b: Int16): Boolean = a > b", ({test}) => {
@@ -658,16 +628,6 @@ describe("last codegen", () => {
                     })
                     it("can bitwise shl", () => {
                         cg("export fun test(a: UInt16, b: Int32): UInt16 = a shl b", ({test}) => {
-                            expect(test(7, 2)).toEqual(7 << 2)
-                        })
-                    })
-                    it("can bitwise ror", () => {
-                        cg("export fun test(a: UInt16, b: Int32): UInt16 = a ror b", ({test}) => {
-                            expect(test(7, 2)).toEqual(7 >> 2)
-                        })
-                    })
-                    it("can bitwise rol", () => {
-                        cg("export fun test(a: UInt16, b: Int32): UInt16 = a rol b", ({test}) => {
                             expect(test(7, 2)).toEqual(7 << 2)
                         })
                     })

--- a/src/last/check.spec.ts
+++ b/src/last/check.spec.ts
@@ -278,10 +278,13 @@ describe("check", () => {
     })
 
     describe('integers', () => {
+        function tx(text: string): [Module, CheckResult] {
+            return t(text)
+        }
         describe("i8", () => {
             describe("bitwise operators", () => {
                 function t(expr: string) {
-                    p(`var a: Int8 = 1t; var b: Int8 = 2t; var v: Int8 = ${expr}`)
+                    tx(`var a: Int8 = 1t; var b: Int8 = 2t; var v: Int8 = ${expr}`)
                 }
 
                 it("can check a bitwise and", () => {
@@ -298,19 +301,13 @@ describe("check", () => {
                 })
                 it("can check a shl", () => {
                     t("a shl 2")
-                })
-                it("can check a ror", () => {
-                    t("a ror 1")
-                })
-                it("can check a rol", () => {
-                    t("a rol 1")
                 })
             })
         })
         describe("i16", () => {
             describe("bitwise operators", () => {
                 function t(expr: string) {
-                    p(`var a: Int16 = 1s; var b: Int16 = 2s; var v: Int16 = ${expr}`)
+                    tx(`var a: Int16 = 1s; var b: Int16 = 2s; var v: Int16 = ${expr}`)
                 }
 
                 it("can check a bitwise and", () => {
@@ -328,18 +325,12 @@ describe("check", () => {
                 it("can check a shl", () => {
                     t("a shl 2")
                 })
-                it("can check a ror", () => {
-                    t("a ror 1")
-                })
-                it("can check a rol", () => {
-                    t("a rol 1")
-                })
             })
         })
         describe("i32", () => {
             describe("bitwise operators", () => {
-                function t(expr: string) {
-                    p(`var a: Int32 = 1; var b: Int32 = 2; var v: Int32 = ${expr}`)
+                function t(expr: string): [Module, CheckResult] {
+                    return tx(`var a: Int32 = 1; var b: Int32 = 2; var v: Int32 = ${expr}`)
                 }
 
                 it("can check a bitwise and", () => {
@@ -368,7 +359,7 @@ describe("check", () => {
         describe("i64", () => {
             describe("bitwise operators", () => {
                 function t(expr: string) {
-                    p(`var a: Int64 = 1l; var b: Int64 = 2l; var v: Int64 = ${expr}`)
+                    tx(`var a: Int64 = 1l; var b: Int64 = 2l; var v: Int64 = ${expr}`)
                 }
 
                 it("can check a bitwise and", () => {
@@ -397,7 +388,7 @@ describe("check", () => {
         describe("u8", () => {
             describe("bitwise operators", () => {
                 function t(expr: string) {
-                    p(`var a: UInt8 = 1ut; var b: UInt8 = 2ut; var v: UInt8 = ${expr}`)
+                    tx(`var a: UInt8 = 1ut; var b: UInt8 = 2ut; var v: UInt8 = ${expr}`)
                 }
 
                 it("can check a bitwise and", () => {
@@ -414,19 +405,13 @@ describe("check", () => {
                 })
                 it("can check a shl", () => {
                     t("a shl 2")
-                })
-                it("can check a ror", () => {
-                    t("a ror 1")
-                })
-                it("can check a rol", () => {
-                    t("a rol 1")
                 })
             })
         })
         describe("u16", () => {
             describe("bitwise operators", () => {
                 function t(expr: string) {
-                    p(`var a: UInt16 = 1us; var b: UInt16 = 2us; var v: UInt16 = ${expr}`)
+                    tx(`var a: UInt16 = 1us; var b: UInt16 = 2us; var v: UInt16 = ${expr}`)
                 }
 
                 it("can check a bitwise and", () => {
@@ -444,18 +429,12 @@ describe("check", () => {
                 it("can check a shl", () => {
                     t("a shl 2")
                 })
-                it("can check a ror", () => {
-                    t("a ror 1")
-                })
-                it("can check a rol", () => {
-                    t("a rol 1")
-                })
             })
         })
         describe("u32", () => {
             describe("bitwise operators", () => {
                 function t(expr: string) {
-                    p(`var a: UInt32 = 1u; var b: UInt32 = 2u; var v: UInt32 = ${expr}`)
+                    tx(`var a: UInt32 = 1u; var b: UInt32 = 2u; var v: UInt32 = ${expr}`)
                 }
 
                 it("can check a bitwise and", () => {
@@ -484,7 +463,7 @@ describe("check", () => {
         describe("u64", () => {
             describe("bitwise operators", () => {
                 function t(expr: string) {
-                    p(`var a: UInt64 = 1ul; var b: UInt64 = 2ul; var v: UInt64 = ${expr}`)
+                    tx(`var a: UInt64 = 1ul; var b: UInt64 = 2ul; var v: UInt64 = ${expr}`)
                 }
 
                 it("can check a bitwise and", () => {

--- a/src/last/check.ts
+++ b/src/last/check.ts
@@ -258,13 +258,21 @@ export function check(module: Module): CheckResult | Diagnostic[] {
                 break
             case LastKind.BitShl:
             case LastKind.BitShr:
+                type = binaryWidenRight(
+                    expression,
+                    expression.left,
+                    expression.right,
+                    Capabilities.Bitwizeable,
+                    scopes
+                )
+                break
             case LastKind.BitRotr:
             case LastKind.BitRotl:
                 type = binaryWidenRight(
                     expression,
                     expression.left,
                     expression.right,
-                    Capabilities.Bitwizeable,
+                    Capabilities.Rotatable,
                     scopes
                 )
                 break


### PR DESCRIPTION
Rotation should only be allowed on rotatable types.
Fixed bitwise check tests to check the bitwise nodes.